### PR TITLE
API Post routes for Like & Unlike

### DIFF
--- a/routes/api/posts.js
+++ b/routes/api/posts.js
@@ -87,4 +87,67 @@ router.delete(
   }
 );
 
+// @route   POST api/posts/like/:id
+//@desc     Like post
+//@access   Private
+router.post(
+  "/like/:id",
+  passport.authenticate("jwt", { session: false }),
+  (req, res) => {
+    Profile.findOne({ user: req.user.id }).then(profile => {
+      Post.findById(req.params.id)
+        .then(post => {
+          if (
+            post.likes.filter(like => like.user.toString() === req.user.id)
+              .length > 0
+          ) {
+            return res
+              .status(400)
+              .json({ alreadyliked: "User already liked this post" });
+          }
+
+          //add user id to likes array
+          post.likes.unshift({ user: req.user.id });
+
+          post.save().then(post => res.json(post));
+        })
+        .catch(err => res.status(404).json({ postnotfound: "No Post found" }));
+    });
+  }
+);
+
+// @route   POST api/posts/unlike/:id
+//@desc     Unlike post
+//@access   Private
+router.post(
+  "/unlike/:id",
+  passport.authenticate("jwt", { session: false }),
+  (req, res) => {
+    Profile.findOne({ user: req.user.id }).then(profile => {
+      Post.findById(req.params.id)
+        .then(post => {
+          if (
+            (post.likes.filter(
+              like => like.user.toString() === req.user.id
+            ).length = 0)
+          ) {
+            return res
+              .status(400)
+              .json({ notliked: "You have not yet liked this post" });
+          }
+
+          //get remove index
+          const removeIndex = post.likes
+            .map(item => item.user.toString())
+            .indexOf(req.user.id);
+
+          post.likes.splice(removeIndex, 1);
+
+          post.save().then(post => res.json(post));
+        })
+        .catch(err => res.status(404).json({ postnotfound: "No Post found" }));
+    });
+  }
+);
+
 module.exports = router;


### PR DESCRIPTION
API Routes to allow a user to Like and Unlike a post.
Validation is in place so a user can only like a post once. 
They can remove their like and add it again.